### PR TITLE
Enable feature for Nfs and Samba shares

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-remoteshare (0.6.4) stable; urgency=low
+
+  * Add possibility to enable/disable shares for Nfs and Samba
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Tue, 28 May 2014 15:00:01 -0500
+
 openmediavault-remoteshare (0.6.3) stable; urgency=low
 
   * Add webdav support

--- a/usr/share/openmediavault/engined/rpc/remoteshare.inc
+++ b/usr/share/openmediavault/engined/rpc/remoteshare.inc
@@ -110,6 +110,7 @@ class OMVRpcServiceRemoteShare extends OMVRpcServiceAbstract {
             throw new OMVException(OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED, $xpath);
 
         // Modify the result object.
+        $object['enable'] = boolval($object['enable']);
         $object['nfs'] = boolval($object['nfs']);
 
         return $object;
@@ -126,6 +127,7 @@ class OMVRpcServiceRemoteShare extends OMVRpcServiceAbstract {
             "type"       : "object",
             "properties" : {
                 "uuid"            : { '.$GLOBALS['OMV_JSONSCHEMA_UUID_UNDEFINED'].' },
+                "enable"          : { "type" : "boolean" },
                 "server"          : { "type" : "string" },
                 "export"          : { "type" : "string" },
                 "sharedfolderref" : { '.$GLOBALS['OMV_JSONSCHEMA_UUID'].' },
@@ -153,6 +155,7 @@ class OMVRpcServiceRemoteShare extends OMVRpcServiceAbstract {
         // Prepare the configuration object.
         $object = array(
             "uuid"            => ($params['uuid'] == $GLOBALS['OMV_UUID_UNDEFINED']) ? OMVUtil::uuid() : $params['uuid'],
+            "enable"          => array_boolval($params, 'enable'),
             "server"          => $params['server'],
             "export"          => $params['export'],
             "sharedfolderref" => $params['sharedfolderref'],
@@ -301,6 +304,7 @@ class OMVRpcServiceRemoteShare extends OMVRpcServiceAbstract {
             throw new OMVException(OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED, $xpath);
 
         // Modify the result object.
+        $object['enable'] = boolval($object['enable']);
         $object['guest']   = boolval($object['guest']);
         $object['usefile'] = boolval($object['usefile']);
 
@@ -318,6 +322,7 @@ class OMVRpcServiceRemoteShare extends OMVRpcServiceAbstract {
             "type"       : "object",
             "properties" : {
                 "uuid"            : { '.$GLOBALS['OMV_JSONSCHEMA_UUID_UNDEFINED'].' },
+                "enable"          : { "type" : "boolean" },
                 "server"          : { "type" : "string" },
                 "smbname"         : { "type" : "string" },
                 "sharedfolderref" : { '.$GLOBALS['OMV_JSONSCHEMA_UUID'].' },
@@ -347,6 +352,7 @@ class OMVRpcServiceRemoteShare extends OMVRpcServiceAbstract {
         // Prepare the configuration object.
         $object = array(
             "uuid"            => ($params['uuid'] == $GLOBALS['OMV_UUID_UNDEFINED']) ? OMVUtil::uuid() : $params['uuid'],
+            "enable"          => array_boolval($params, 'enable'),
             "server"          => $params['server'],
             "smbname"         => $params['smbname'],
             "sharedfolderref" => $params['sharedfolderref'],

--- a/usr/share/openmediavault/mkconf/fstab.d/11remoteshares
+++ b/usr/share/openmediavault/mkconf/fstab.d/11remoteshares
@@ -27,8 +27,9 @@ count=$(omv_config_get_count "//services/remoteshare/nfsshares/nfsshare");
 # remote nfs share entries
 index=0;
 while [ ${index} -le ${count} ]; do
+    enable=$(omv_config_get "//services/remoteshare/nfsshares/nfsshare[position()=${index}]/enable")
     entry=$(omv_config_get "//services/remoteshare/nfsshares/nfsshare[position()=${index}]/fstab_line")
-    if [ "${entry}" != "" ]; then
+    if [ "${enable}" != "0" -a "${entry}" != "" ]; then
         echo ${entry}
     fi
     index=$(( ${index} + 1 ))
@@ -39,8 +40,9 @@ count=$(omv_config_get_count "//services/remoteshare/smbshares/smbshare");
 # remote samba share entries
 index=0;
 while [ ${index} -le ${count} ]; do
+    enable=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/enable")
     entry=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/fstab_line")
-    if [ "${entry}" != "" ]; then
+    if [ "${enable}" != "0" -a "${entry}" != "" ]; then
         echo ${entry}
     fi
     index=$(( ${index} + 1 ))

--- a/usr/share/openmediavault/mkconf/remoteshare
+++ b/usr/share/openmediavault/mkconf/remoteshare
@@ -25,19 +25,55 @@ OMV_REMOTESHARE_SECTION=${OMV_REMOTESHARE_SECTION:-"omv-remoteshare"}
 OMV_DAVFS2_CONFIG=${OMV_DAVFS2_CONFIG:-"/etc/davfs2/davfs2.conf"}
 OMV_DAVFS2_SECRETS=${OMV_DAVFS2_SECRETS:-"/etc/davfs2/secrets"}
 
+
+count=$(omv_config_get_count "//services/remoteshare/nfsshares/nfsshare");
+
+# remote nfs share entries
+index=1;
+while [ ${index} -le ${count} ]; do
+    enable=$(omv_config_get "//services/remoteshare/nfsshares/nfsshare[position()=${index}]/enable")
+    server=$(omv_config_get "//services/remoteshare/nfsshares/nfsshare[position()=${index}]/server")
+    export=$(omv_config_get "//services/remoteshare/nfsshares/nfsshare[position()=${index}]/export")
+    sfref=$(omv_config_get "//services/remoteshare/nfsshares/nfsshare[position()=${index}]/sharedfolderref")
+    sfpath=$(omv_get_sharedfolder_path "${sfref}")
+    sfpath=${sfpath%/} #strip off trailing slash, if any
+
+    if [ ${enable} -eq 0 ]; then
+        if mount | grep -q -E "^${server}:${export} on ${sfpath}"; then
+            # entry is not enabled but currently mounted, so unmount it
+            umount ${sfpath} >/dev/null 2>&1
+        fi
+    fi
+
+    index=$(( ${index} + 1 ))
+done;
+
+
 count=$(omv_config_get_count "//services/remoteshare/smbshares/smbshare");
 
 # remote samba share entries
 index=1;
 while [ ${index} -le ${count} ]; do
+    enable=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/enable")
     credfile=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/usefile")
     sfref=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/sharedfolderref")
     username=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/username")
     password=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/password")
+    server=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/server")
+    smbname=$(omv_config_get "//services/remoteshare/smbshares/smbshare[position()=${index}]/smbname")
+    sfpath=$(omv_get_sharedfolder_path "${sfref}")
+    sfpath=${sfpath%/} #strip off trailing slash, if any
 
     if [ "${credfile}" != "0" ]; then
         echo "username=${username}" > ${CRED_FILE}${sfref}
         echo "password=${password}" >> ${CRED_FILE}${sfref}
+    fi
+
+    if [ ${enable} -eq 0 ]; then
+        if mount | grep -q -E "^//${server}/${smbname} on ${sfpath}"; then
+            # entry is not enabled but currently mounted, so unmount it
+            umount ${sfpath} >/dev/null 2>&1
+        fi
     fi
 
     index=$(( ${index} + 1 ))

--- a/var/www/openmediavault/js/omv/module/admin/service/remoteshare/Nfs.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/remoteshare/Nfs.js
@@ -48,6 +48,11 @@ Ext.define("OMV.module.admin.service.remoteshare.NfsShare", {
     getFormItems : function() {
         var me = this;
         return [{
+            xtype      : "checkbox",
+            name       : "enable",
+            fieldLabel : _("Enable"),
+            checked    : true
+        },{
             xtype      : "textfield",
             name       : "server",
             fieldLabel : _("Server"),
@@ -108,6 +113,17 @@ Ext.define("OMV.module.admin.service.remoteshare.NfsShares", {
     stateful          : true,
     stateId           : "1649057b-b1c0-1c48-a4c1-8c8d1fe52d7b",
     columns           : [{
+        xtype     : "booleaniconcolumn",
+        text      : _("Enabled"),
+        sortable  : true,
+        dataIndex : "enable",
+        stateId   : "enable",
+        align     : "center",
+        width     : 80,
+        resizable : false,
+        trueIcon  : "switch_on.png",
+        falseIcon : "switch_off.png"
+    },{
         text      : _("Server"),
         sortable  : true,
         dataIndex : "server",
@@ -133,6 +149,7 @@ Ext.define("OMV.module.admin.service.remoteshare.NfsShares", {
                     idProperty  : "uuid",
                     fields      : [
                         { name : "uuid", type: "string" },
+                        { name : "enable", type: "boolean" },
                         { name : "server", type: "string" },
                         { name : "export", type: "string" },
                         { name : "sharename", type: "string" }

--- a/var/www/openmediavault/js/omv/module/admin/service/remoteshare/Samba.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/remoteshare/Samba.js
@@ -74,6 +74,11 @@ Ext.define("OMV.module.admin.service.remoteshare.SmbShare", {
     getFormItems : function() {
         var me = this;
         return [{
+            xtype      : "checkbox",
+            name       : "enable",
+            fieldLabel : _("Enable"),
+            checked    : true
+        },{
             xtype      : "textfield",
             name       : "server",
             fieldLabel : _("Server"),
@@ -143,6 +148,17 @@ Ext.define("OMV.module.admin.service.remoteshare.SmbShares", {
     stateful          : true,
     stateId           : "1649057b-b1c0-1c48-a4c1-8c8d1fe52d7b",
     columns           : [{
+        xtype     : "booleaniconcolumn",
+        text      : _("Enabled"),
+        sortable  : true,
+        dataIndex : "enable",
+        stateId   : "enable",
+        align     : "center",
+        width     : 80,
+        resizable : false,
+        trueIcon  : "switch_on.png",
+        falseIcon : "switch_off.png"
+    },{
         text      : _("Server"),
         sortable  : true,
         dataIndex : "server",
@@ -173,6 +189,7 @@ Ext.define("OMV.module.admin.service.remoteshare.SmbShares", {
                     idProperty  : "uuid",
                     fields      : [
                         { name : "uuid", type: "string" },
+                        { name : "enable", type: "boolean" },
                         { name : "server", type: "string" },
                         { name : "smbname", type: "string" },
                         { name : "sharename", type: "string" },


### PR DESCRIPTION
I quickly implemented the enable feature for the Nfs and Samba shares. I hope everything works as expected as I did not do that much testing on it.
As I don't have neither Samba nor Nfs server at hand here I could not fully test if the shares get mounted/unmounted properly. Especially unmounting when being disabled needs more testing as I added this functionality.
